### PR TITLE
Add minimal trading utilities

### DIFF
--- a/alphavibe/__init__.py
+++ b/alphavibe/__init__.py
@@ -1,0 +1,8 @@
+__all__ = [
+    "fetcher",
+    "storage",
+    "schema",
+    "metrics",
+    "backtest_engine",
+    "cli",
+]

--- a/alphavibe/backtest_engine.py
+++ b/alphavibe/backtest_engine.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import List, Dict, Type
+
+
+def run_backtest(strategy_cls: Type, data: List[Dict[str, float]], cash: float = 10_000) -> Dict[str, float]:
+    """Stub for backtest."""
+    # Placeholder: implement with actual library
+    prices = [row["close"] for row in data]
+    ret = prices[-1] - prices[0]
+    return {"pnl": ret, "sharpe": 0.0, "drawdown": 0.0}

--- a/alphavibe/cli.py
+++ b/alphavibe/cli.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta
+
+from .fetcher import fetch_ohlcv
+from .storage import save_df
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="alphavibe")
+    sub = parser.add_subparsers(dest="cmd")
+
+    fetch_p = sub.add_parser("fetch", help="Fetch market data")
+    fetch_p.add_argument("symbol")
+    fetch_p.add_argument("timeframe")
+    fetch_p.add_argument("--days", type=int, default=1)
+
+    args = parser.parse_args(argv)
+    if args.cmd == "fetch":
+        end = datetime.utcnow()
+        start = end - timedelta(days=args.days)
+        rows = fetch_ohlcv(args.symbol, args.timeframe, start.isoformat(), end.isoformat())
+        save_df(rows, symbol=args.symbol, timeframe=args.timeframe)
+        print(f"Fetched {len(rows)} rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/alphavibe/config.py
+++ b/alphavibe/config.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any, Dict
+
+
+CONFIG_FILE = Path(__file__).with_name("settings.toml")
+
+
+def load_config(path: Path | None = None) -> Dict[str, Any]:
+    """Load settings from TOML file."""
+    cfg_path = path or CONFIG_FILE
+    if not cfg_path.exists():
+        return {}
+    with cfg_path.open("rb") as f:
+        return tomllib.load(f)

--- a/alphavibe/fetcher.py
+++ b/alphavibe/fetcher.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import urllib.request
+from datetime import datetime
+from typing import List, Dict
+
+API_URL = (
+    "https://api.binance.com/api/v3/klines?symbol={symbol}&interval={interval}&startTime={start}&endTime={end}&limit=1000"
+)
+
+
+def _ts_to_ms(ts: str | int) -> int:
+    if isinstance(ts, int):
+        return ts
+    dt = datetime.fromisoformat(ts)
+    return int(dt.timestamp() * 1000)
+
+
+def fetch_ohlcv(symbol: str, timeframe: str, since: str | int, until: str | int) -> List[Dict[str, float]]:
+    """Fetch OHLCV data from Binance public API."""
+    start_ms = _ts_to_ms(since)
+    end_ms = _ts_to_ms(until)
+    url = API_URL.format(symbol=symbol.upper(), interval=timeframe, start=start_ms, end=end_ms)
+    with urllib.request.urlopen(url) as resp:
+        data = json.loads(resp.read().decode())
+    result = []
+    for item in data:
+        result.append(
+            {
+                "timestamp": int(item[0]) // 1000,
+                "open": float(item[1]),
+                "high": float(item[2]),
+                "low": float(item[3]),
+                "close": float(item[4]),
+                "volume": float(item[5]),
+            }
+        )
+    return result

--- a/alphavibe/logger.py
+++ b/alphavibe/logger.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import logging
+from logging import Logger
+
+
+def get_logger(name: str) -> Logger:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    return logging.getLogger(name)

--- a/alphavibe/metrics.py
+++ b/alphavibe/metrics.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import List
+
+
+def total_return(prices: List[float]) -> float:
+    if not prices:
+        return 0.0
+    return (prices[-1] - prices[0]) / prices[0]
+
+
+def max_drawdown(prices: List[float]) -> float:
+    peak = prices[0]
+    drawdowns = []
+    for p in prices:
+        if p > peak:
+            peak = p
+        drawdowns.append((peak - p) / peak)
+    return max(drawdowns)
+
+
+def sharpe_ratio(returns: List[float]) -> float:
+    if not returns:
+        return 0.0
+    avg = sum(returns) / len(returns)
+    var = sum((r - avg) ** 2 for r in returns) / len(returns)
+    std = var ** 0.5
+    if std == 0:
+        return 0.0
+    return (avg / std) * (len(returns) ** 0.5)

--- a/alphavibe/schema.py
+++ b/alphavibe/schema.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import List, Dict
+
+REQUIRED_COLUMNS = {"timestamp", "open", "high", "low", "close", "volume"}
+
+
+def validate_ohlcv(rows: List[Dict[str, float]]) -> None:
+    """Validate OHLCV rows."""
+    if not rows:
+        raise ValueError("No data")
+    for row in rows:
+        if set(row) != REQUIRED_COLUMNS:
+            raise ValueError("Invalid columns")
+        if any(v is None for v in row.values()):
+            raise ValueError("NaN detected")

--- a/alphavibe/storage.py
+++ b/alphavibe/storage.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import List, Dict
+
+DATA_DIR = Path(__file__).with_name("data")
+
+
+def save_df(rows: List[Dict[str, float]], *, symbol: str, timeframe: str) -> Path:
+    """Save rows to CSV file."""
+    exchange = "binance"
+    path = DATA_DIR / exchange / symbol / f"{timeframe}.csv"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    return path
+
+
+def load_df(symbol: str, timeframe: str, start: str | None = None, end: str | None = None) -> List[Dict[str, float]]:
+    """Load rows from CSV file."""
+    exchange = "binance"
+    path = DATA_DIR / exchange / symbol / f"{timeframe}.csv"
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        data = [
+            {k: float(v) if k != "timestamp" else int(v) for k, v in row.items()}
+            for row in reader
+        ]
+    return data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,10 @@
+from alphavibe.cli import main
+
+
+def test_cli_no_args(capsys):
+    try:
+        main([])
+    except SystemExit:
+        pass
+    captured = capsys.readouterr()
+    assert "usage" in captured.err or captured.out

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,21 @@
+import sys, pathlib
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+from alphavibe.metrics import total_return, max_drawdown, sharpe_ratio
+
+
+def test_total_return():
+    prices = [1, 2, 3]
+    assert total_return(prices) == 2.0
+
+
+def test_max_drawdown():
+    prices = [3, 2, 1]
+    assert max_drawdown(prices) == (3 - 1) / 3
+
+
+def test_sharpe_ratio():
+    returns = [1, -1, 1, -1]
+    sr = sharpe_ratio(returns)
+    assert abs(sr) < 1e-6


### PR DESCRIPTION
## Summary
- add barebones data fetching from Binance API
- add simple CSV storage helpers
- add metrics functions and stub backtest engine
- introduce a basic CLI with argparse
- include simple unit tests

## Testing
- `python tests/test_metrics.py`
- *(tests require pytest which is unavailable)*
